### PR TITLE
chore: Update dependabot versioning strategy for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Setting `versioning-strategy` to `increase-if-necessary` will prevent dependabot from pinning new versions if they were declared loosely (e.g. `^1.0.0`).