### PR TITLE
chore: Group @typescript-eslint dependencies in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     versioning-strategy: increase-if-necessary
     schedule:
       interval: "daily"
+    groups:
+      "@typescript-eslint":
+        patterns:
+          - "^@typescript-eslint/.*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
`@typescript-eslint` packages get released with the same version (see https://typescript-eslint.io/users/versioning). Let's group them together in a single dependabot PR to keep things tidy.