### PR TITLE
feat: Enforce `react/self-closing-comp` rule for components and HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,13 @@ module.exports = {
     "prettier/prettier": "error",
     "react/jsx-no-useless-fragment": "error",
     "react/jsx-sort-props": ["error", { shorthandLast: true }],
+    "react/self-closing-comp": [
+      "error",
+      {
+        component: true,
+        html: true,
+      },
+    ],
     "sort-imports": ["error", { ignoreDeclarationSort: true }],
   },
   settings: {


### PR DESCRIPTION
Adds a rule to error on [`react/self-closing-comp`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md).