### PR TITLE
fix: Fix @typescript-eslint dependencies group in dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     groups:
       "@typescript-eslint":
         patterns:
-          - "^@typescript-eslint/.*"
+          - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This is a followup to https://github.com/anthony-j-castro/eslint-config/pull/40. It seems the config might not be correct, since dependabot ended up opening separate PRs for these packages.