### PR TITLE
chore: Disable success comments on PRs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript", "typescript"],
   "typescript.validate.enable": true

--- a/release.config.js
+++ b/release.config.js
@@ -18,7 +18,12 @@ const config = {
           "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       },
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        successComment: false,
+      },
+    ],
   ],
 };
 


### PR DESCRIPTION
Success comments from the semantic-release bot ([example](https://github.com/anthony-j-castro/eslint-config/pull/39#issuecomment-1823757475)) are helpful on actual feature PRs, but kind of annoying on automatic dependency updates since those are currently configured to happen more frequently. Since there's currently no way to conditionally comment, let's disable them altogether.

This PR also includes a change to editor settings that was automatically applied after updating VS Code (see https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto).