### PR TITLE
feat: Enforce sorting of destructured object keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Since this config uses various other configs and plugins as peer dependencies,
 we also need to install them:
 
 ```bash
-npm install --save-dev --save-exact @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks prettier typescript
+npm install --save-dev --save-exact @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks sort-destructure-keys prettier typescript
 ```
 
 Finally, copy and paste this starter config in a new `eslintrc.js` file:

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
     ],
     "sort-destructure-keys/sort-destructure-keys": [
       "error",
-      { caseSensitive: false },
+      { caseSensitive: true },
     ],
     "sort-imports": ["error", { ignoreDeclarationSort: true }],
   },

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     },
   ],
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint", "prettier"],
+  plugins: ["@typescript-eslint", "prettier", "sort-destructure-keys"],
   rules: {
     "@typescript-eslint/no-unused-vars": "error",
     "import/newline-after-import": "error",
@@ -57,6 +57,10 @@ module.exports = {
         component: true,
         html: true,
       },
+    ],
+    "sort-destructure-keys/sort-destructure-keys": [
+      "error",
+      { caseSensitive: false },
     ],
     "sort-imports": ["error", { ignoreDeclarationSort: true }],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.0.0",
         "eslint-plugin-react-hooks": "^4.0.0",
-        "eslint-plugin-sort-destructure-keys": "1.5.0",
+        "eslint-plugin-sort-destructure-keys": "^1.5.0",
         "prettier": "^3.0.0",
         "semantic-release": "23.0.0",
         "typescript": "^5.0.0"
@@ -38,6 +38,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.0.0",
         "eslint-plugin-react-hooks": "^4.0.0",
+        "eslint-plugin-sort-destructure-keys": "^1.5.0",
         "prettier": "^3.0.0",
         "typescript": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.0.0",
         "eslint-plugin-react-hooks": "^4.0.0",
+        "eslint-plugin-sort-destructure-keys": "1.5.0",
         "prettier": "^3.0.0",
         "semantic-release": "23.0.0",
         "typescript": "^5.0.0"
@@ -2815,6 +2816,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-sort-destructure-keys": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.5.0.tgz",
+      "integrity": "sha512-xGLyqHtbFXZNXQSvAiQ4ISBYokrbUywEhmaA50fKtSKgceCv5y3zjoNuZwcnajdM6q29Nxj+oXC9KcqfMsAPrg==",
+      "dev": true,
+      "dependencies": {
+        "natural-compare-lite": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "3 - 8"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -4593,6 +4609,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
     "node_modules/neo-async": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^4.0.0",
+    "eslint-plugin-sort-destructure-keys": "^1.5.0",
     "prettier": "^3.0.0",
     "semantic-release": "23.0.0",
     "typescript": "^5.0.0"
@@ -48,6 +49,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.0.0",
     "eslint-plugin-react-hooks": "^4.0.0",
+    "eslint-plugin-sort-destructure-keys": "^1.5.0",
     "prettier": "^3.0.0",
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
Adds the [`eslint-plugin-sort-destructure-keys`](https://www.npmjs.com/package/eslint-plugin-sort-destructure-keys) plugin and enables the `sort-destructure-keys/sort-destructure-keys` rule.