### PR TITLE
feat: Enforce double quotes for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Since this config uses various other configs and plugins as peer dependencies,
 we also need to install them:
 
 ```bash
-npm install --save-dev --save-exact @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks sort-destructure-keys prettier typescript
+npm install --save-dev --save-exact @stylistic/eslint-plugin @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks sort-destructure-keys prettier typescript
 ```
 
 Finally, copy and paste this starter config in a new `eslintrc.js` file:

--- a/index.js
+++ b/index.js
@@ -17,8 +17,18 @@ module.exports = {
     },
   ],
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint", "prettier", "sort-destructure-keys"],
+  plugins: [
+    "@stylistic",
+    "@typescript-eslint",
+    "prettier",
+    "sort-destructure-keys",
+  ],
   rules: {
+    "@stylistic/quotes": [
+      "error",
+      "double",
+      { allowTemplateLiterals: false, avoidEscape: true },
+    ],
     "@typescript-eslint/no-unused-vars": "error",
     "import/newline-after-import": "error",
     "import/no-named-as-default": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "9.2.6",
         "@semantic-release/npm": "11.0.2",
+        "@stylistic/eslint-plugin": "1.5.4",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",
@@ -1146,6 +1147,86 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-1.5.4.tgz",
+      "integrity": "sha512-zWPXr+O67GC9KDAFkbL1U9UVqE6Iv69YMKhkIECCmE0GvClUJwdfsimm4XebEDondV7kfjMrTDZaYfrI5aS0Jg==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "1.5.4",
+        "@stylistic/eslint-plugin-jsx": "1.5.4",
+        "@stylistic/eslint-plugin-plus": "1.5.4",
+        "@stylistic/eslint-plugin-ts": "1.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-1.5.4.tgz",
+      "integrity": "sha512-3ctWb3NvJNV1MsrZN91cYp2EGInLPSoZKphXIbIRx/zjZxKwLDr9z4LMOWtqjq14li/OgqUUcMq5pj8fgbLoTw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-jsx": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-1.5.4.tgz",
+      "integrity": "sha512-JUfrpCkeBCqt1IZ4QsP4WgxGza4PhK4LPbc0VnCjHKygl+rgqoDAovqOuzFJ49wJ4Ix3r6OIHFuwiBGswZEVvg==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "^1.5.4",
+        "estraverse": "^5.3.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-plus": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-1.5.4.tgz",
+      "integrity": "sha512-dI0Cs5vYX/0uMhQDY+NK0cKQ0Pe9B6jWYxd0Ndud+mNloDaVLrsmJocK4zn+YfhGEDs1E4Nk5uAPZEumIpDuSg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^6.19.0"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-ts": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-1.5.4.tgz",
+      "integrity": "sha512-NZDFVIlVNjuPvhT+0Cidm5IS3emtx338xbJTqs2xfOVRDGTpYwRHhNVEGa1rFOpYHmv0sAj6+OXbMDn7ul0K/g==",
+      "dev": true,
+      "dependencies": {
+        "@stylistic/eslint-plugin-js": "1.5.4",
+        "@typescript-eslint/utils": "^6.19.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1436,9 +1517,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "9.2.6",
     "@semantic-release/npm": "11.0.2",
+    "@stylistic/eslint-plugin": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
@@ -40,6 +41,7 @@
     "typescript": "^5.0.0"
   },
   "peerDependencies": {
+    "@stylistic/eslint-plugin": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",


### PR DESCRIPTION
Adds the [`@stylistic/eslint-plugin`](https://www.npmjs.com/package/@stylistic/eslint-plugin) plugin and enables the [`@stylistic/quotes`](https://eslint.style/rules/default/quotes) rule with the options to:
* Avoid template literals if they are not necessary (i.e. there's no string interpolation)
* Avoid escaping double quotes by using single quotes for the string instead