### PR TITLE
feat: Migrate deprecated rules to stylistic plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ module.exports = {
     "sort-destructure-keys",
   ],
   rules: {
+    "@stylistic/jsx-self-closing-comp": [
+      "error",
+      {
+        component: true,
+        html: true,
+      },
+    ],
     "@stylistic/jsx-sort-props": ["error", { shorthandLast: true }],
     "@stylistic/padding-line-between-statements": [
       "error",
@@ -61,13 +68,6 @@ module.exports = {
     ],
     "prettier/prettier": "error",
     "react/jsx-no-useless-fragment": "error",
-    "react/self-closing-comp": [
-      "error",
-      {
-        component: true,
-        html: true,
-      },
-    ],
     "sort-destructure-keys/sort-destructure-keys": [
       "error",
       { caseSensitive: true },

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     "plugin:import/typescript",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
+    "plugin:@stylistic/disable-legacy",
     "plugin:prettier/recommended",
   ],
   overrides: [

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ module.exports = {
     "sort-destructure-keys",
   ],
   rules: {
+    "@stylistic/jsx-sort-props": ["error", { shorthandLast: true }],
+    "@stylistic/padding-line-between-statements": [
+      "error",
+      { blankLine: "always", next: "return", prev: "*" },
+    ],
     "@stylistic/quotes": [
       "error",
       "double",
@@ -54,13 +59,8 @@ module.exports = {
         ],
       },
     ],
-    "padding-line-between-statements": [
-      "error",
-      { blankLine: "always", next: "return", prev: "*" },
-    ],
     "prettier/prettier": "error",
     "react/jsx-no-useless-fragment": "error",
-    "react/jsx-sort-props": ["error", { shorthandLast: true }],
     "react/self-closing-comp": [
       "error",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "9.2.6",
         "@semantic-release/npm": "11.0.2",
-        "@stylistic/eslint-plugin": "1.5.4",
+        "@stylistic/eslint-plugin": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",
@@ -30,6 +30,7 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
+        "@stylistic/eslint-plugin": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.0.0",


### PR DESCRIPTION
These rules were identified using the [migration plugin](https://eslint.style/guide/migration#eslint-migrate-plugin).