### PR TITLE
docs: Remove explicit installation of peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ To install the latest version as a dependency of a project:
 npm install --save-dev "https://github.com/anthony-j-castro/eslint-config.git#semver:1.2.0"
 ```
 
-Since this config uses various other configs and plugins as peer dependencies,
-we also need to install them:
+Plugins and configs will be installed automatically as peer dependencies, but we
+still need to explicitly install some dependencies:
 
 ```bash
-npm install --save-dev --save-exact @stylistic/eslint-plugin @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-sort-destructure-keys eslint-plugin-typescript-sort-keys prettier typescript
+npm install --save-dev --save-exact eslint prettier typescript
 ```
 
 Finally, copy and paste this starter config in a new `eslintrc.js` file:

--- a/README.md
+++ b/README.md
@@ -10,14 +10,7 @@ To install the latest version as a dependency of a project:
 npm install --save-dev "https://github.com/anthony-j-castro/eslint-config.git#semver:1.2.0"
 ```
 
-Plugins and configs will be installed automatically as peer dependencies, but we
-still need to explicitly install some dependencies:
-
-```bash
-npm install --save-dev --save-exact eslint prettier typescript
-```
-
-Finally, copy and paste this starter config in a new `eslintrc.js` file:
+Then, copy and paste this starter config in a new `eslintrc.js` file:
 
 ```javascript
 module.exports = {


### PR DESCRIPTION
As of npm version 7, peer dependencies get installed automatically and no longer need to explicitly installed if they aren't used directly.