### PR TITLE
feat: Enforce consistent brace style for simple arrow function returns

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = {
       { allowTemplateLiterals: false, avoidEscape: true },
     ],
     "@typescript-eslint/no-unused-vars": "error",
+    "arrow-body-style": ["error", "as-needed"],
     "import/newline-after-import": "error",
     "import/no-named-as-default": "off",
     "import/no-relative-packages": "error",


### PR DESCRIPTION
Enables the [`arrow-body-style`](https://eslint.org/docs/latest/rules/arrow-body-style) rule to ensure that unnecessary braces around the function body are removed.