### PR TITLE
chore: Update dependabot versioning strategy to always increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: increase
     schedule:
       interval: "daily"
       time: "18:00"


### PR DESCRIPTION
This might need further tweaking for peer dependencies in a separate PR.