### PR TITLE
feat: Enforce sorting union and intersection types

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = {
       { allowTemplateLiterals: false, avoidEscape: true },
     ],
     "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/sort-type-constituents": "error",
     "arrow-body-style": ["error", "as-needed"],
     "import/newline-after-import": "error",
     "import/no-named-as-default": "off",


### PR DESCRIPTION
Enables the [`sort-type-constituents`](https://typescript-eslint.io/rules/sort-type-constituents/) rule so that union and intersection types are sorted alphabetically.