### PR TITLE
feat: Enable `curly` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/sort-type-constituents": "error",
     "arrow-body-style": ["error", "as-needed"],
+    curly: ["error", "all"],
     "import/newline-after-import": "error",
     "import/no-named-as-default": "off",
     "import/no-relative-packages": "error",


### PR DESCRIPTION
Enables the [`curly`](https://eslint.org/docs/latest/rules/curly) rule with the [`all` option](https://eslint.org/docs/latest/rules/curly#all) so that control statements always have curly braces.