### PR TITLE
feat: Enforce a blank line before a `break` statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
     "@stylistic/jsx-sort-props": ["error", { shorthandLast: true }],
     "@stylistic/padding-line-between-statements": [
       "error",
+      { blankLine: "always", next: "break", prev: "*" },
       { blankLine: "always", next: "return", prev: "*" },
     ],
     "@stylistic/quotes": [


### PR DESCRIPTION
Updates the [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/js/padding-line-between-statements) rule options to enforce a blank line before the `break` statement within `switch` statements.

The rationale here is that `break` statements mark the end of a block, which is similar to how `return` statements can be used. So both should receive the same formatting.