### PR TITLE
feat: Enforce a blank line between `case` and `default` statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
     "@stylistic/jsx-sort-props": ["error", { shorthandLast: true }],
     "@stylistic/padding-line-between-statements": [
       "error",
+      { blankLine: "always", next: "*", prev: ["case", "default"] },
       { blankLine: "always", next: "break", prev: "*" },
       { blankLine: "always", next: "return", prev: "*" },
     ],


### PR DESCRIPTION
Updates the [`@stylistic/padding-line-between-statements`](https://eslint.style/rules/js/padding-line-between-statements) rule options to enforce a blank line between `case` and `default` statements within `switch` statements.