### PR TITLE
feat: Enforce specifying radix when using parseInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ module.exports = {
       },
     ],
     "prettier/prettier": "error",
+    radix: ["error", "always"],
     "react/jsx-no-useless-fragment": "error",
   },
   settings: {


### PR DESCRIPTION
Enables the [`radix`](https://eslint.org/docs/latest/rules/radix) rule so that the radix is required when using `parseInt`.