### PR TITLE
feat: Sort types last in named imports list

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,12 @@ module.exports = {
         groups: ["unknown", "shorthand"],
       },
     ],
+    "perfectionist/sort-named-imports": [
+      "error",
+      {
+        groupKind: "values-first",
+      },
+    ],
     "perfectionist/sort-object-types": [
       "error",
       { groupKind: "required-first" },


### PR DESCRIPTION
Sets the [`groupKind`](https://perfectionist.dev/rules/sort-named-imports#groupkind) option on the `sort-named-imports` rule to `"values-first"` so that types are at the end of the list.