### PR TITLE
fix: Always sort naturally, and other fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   env: { node: true },
   extends: "./index.js",
+  ignorePatterns: ["**/*.json"],
   root: true,
   rules: {
     "perfectionist/sort-objects": "error",

--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ module.exports = {
         "@typescript-eslint/no-require-imports": "off",
       },
     },
+    {
+      files: ["*.json"],
+      rules: {
+        "@typescript-eslint/no-unused-expressions": "off",
+      },
+    },
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["@stylistic", "@typescript-eslint", "prettier", "perfectionist"],

--- a/index.js
+++ b/index.js
@@ -61,14 +61,20 @@ module.exports = {
     "perfectionist/sort-imports": [
       "error",
       {
+        customGroups: {
+          value: {
+            fontsource: ["@fontsource-variable/*"],
+          },
+        },
         groups: [
           "builtin",
           "external",
           "internal",
           "sibling",
-          "index",
           "unknown",
-          "side-effect-style",
+          "index",
+          "fontsource",
+          "style",
         ],
         newlinesBetween: "never",
       },
@@ -115,6 +121,7 @@ module.exports = {
     },
     perfectionist: {
       ignoreCase: false,
+      type: "natural",
     },
     react: {
       version: "detect",


### PR DESCRIPTION
It turns out that even though I'm using the natural sort rules extension, the `type` will default back to `alphabetical` if I tweak the settings manually. The solution is to redefine the `type` down in the settings for the perfectionist plugin.

This also fixes a minor issue I was seeing in VS Code on JSON files.