### PR TITLE
fix: Allow empty interfaces if they extend from a single base interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ module.exports = {
       "double",
       { allowTemplateLiterals: false, avoidEscape: true },
     ],
+    "@typescript-eslint/no-empty-object-type": [
+      "error",
+      { allowInterfaces: "with-single-extends" },
+    ],
     "@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "none" }],
     "arrow-body-style": ["error", "as-needed"],
     curly: ["error", "all"],


### PR DESCRIPTION
Updates the `no-empty-object-type` with the `"with-single-extends"` value for the [`allowInterfaces`](https://typescript-eslint.io/rules/no-empty-object-type/#allowinterfaces) setting.